### PR TITLE
Add splash option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ You can also use any major tags like `@v1` for any `@v1.*.*`
  | `--onefile`,                       `-F` | `--upx-exclude <FILE>`                  |
  | `--ascii`,                         `-a` | `--add-data <SRC;DEST or SRC:DEST>`     |
  | `--console`,    `--nowindowed`,    `-c` | `--add-binary <SRC;DEST or SRC:DEST>`   |
- | `--windowed`,   `--noconsole`,     `-w` | `--collect-data <MODULENAME>`
+ | `--windowed`,   `--noconsole`,     `-w` | `--collect-data <MODULENAME>`           |
+ | `--splash`
 
 
 <br>

--- a/src/mods.py
+++ b/src/mods.py
@@ -42,6 +42,7 @@ pyOptions = [
 
     '--name <NAME>',                    '-n <NAME>',
     '--icon <FILEICON>',                '-i <FILEICON>',
+    '--splash <IMAGEFILE>',
 ]
 specOptions = [
     '--ascii',                          '-a',


### PR DESCRIPTION
Splash was missing from the parameter list, even though it is stable *enough* to include.
This PR adds it to the available options.