### PR TITLE
Update actions/upload-artifact from v3 to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -103,14 +103,14 @@ runs:
     - name: (Upload) Executable
       id: artifact_upload
       if: inputs.upload_exe_with_name != ''
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.upload_exe_with_name }}
         path: ${{ inputs.exe_path }}
     
     - name: (Upload) generated spec file - if .py
       if: endsWith(inputs.spec, '.py')
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Generated spec file
         path: ${{ steps.mods.outputs.spec_name }}.spec


### PR DESCRIPTION
Github's deprecated v3 of upload-artifact, so it must be changed to v4.